### PR TITLE
Add direct url method for storage backed attributes

### DIFF
--- a/lib/s3/storage_backed_attribute.rb
+++ b/lib/s3/storage_backed_attribute.rb
@@ -164,9 +164,11 @@ module S3
     
     # gets the authenticated url for a storage backed attribute
     #
+    # @oarams [String] filename the filename to get the direct link for
+    # @params [Hash] opts options to control authenticated url thats generated. Valid options are [:expires, :expires_in]
     # @return [String] url for the attribute
-    def direct_url(filename)
-      s3.authenticated_url(service.storage_path, filename) 
+    def direct_url(filename, opts = {})
+      s3.authenticated_url(service.storage_path, filename, opts) 
     end
 
     # get an s3 helper

--- a/lib/s3/storage_backed_attribute.rb
+++ b/lib/s3/storage_backed_attribute.rb
@@ -161,6 +161,13 @@ module S3
 
       @content_changed = false
     end
+    
+    # gets the authenticated url for a storage backed attribute
+    #
+    # @return [String] url for the attribute
+    def direct_url(filename)
+      s3.authenticated_url(service.storage_path, filename) 
+    end
 
     # get an s3 helper
     #

--- a/lib/storage_backed_attributes.rb
+++ b/lib/storage_backed_attributes.rb
@@ -95,6 +95,10 @@ module StorageBackedAttributes
             self.send("#{name}_attribute").content(self.send("#{name}_filename"), &block)                               #       content_attribute.content(content_filename, &block)
           end                                                                                                           #   end
         end                                                                                                             # end
+        
+        define_method "#{name}_direct_url" do
+          self.send("#{name}_attribute").direct_url(self.send("#{name}_filename"))
+        end
 
         # setter for the attribute
         define_method "#{name}=" do |val|                                                                               # def content=(val)

--- a/test/unit/s3/storage_backed_attribute_test.rb
+++ b/test/unit/s3/storage_backed_attribute_test.rb
@@ -71,6 +71,17 @@ module S3
         assert_equal 128, @storage_backed_attribute.raw_content_size
       end
     end
+    
+    context 'direct url' do
+      setup do
+        @s3_helper = ::S3::S3Helper.new(@storage_backed_attribute.storage_bucket, StorageBackedAttributes.storage_endpoint_config)
+      end
+      
+      should 'return the authenticated url for a storage backed attribute' do
+        expected_url = @s3_helper.authenticated_url(@storage_backed_attribute.service.storage_path, @filename) 
+        assert_equal expected_url, @storage_backed_attribute.direct_url(@filename)
+      end
+    end
 
     context 'write_content_to_s3' do
 
@@ -103,7 +114,7 @@ module S3
           assert_equal sha.hexdigest(file.body), @storage_backed_attribute.stored_content_digest
         end
       end
-
+      
       context 'when the content is already stored' do
         context 'when the raw content digest is present' do
           context 'and match' do

--- a/test/unit/s3/storage_backed_attribute_test.rb
+++ b/test/unit/s3/storage_backed_attribute_test.rb
@@ -81,6 +81,21 @@ module S3
         expected_url = @s3_helper.authenticated_url(@storage_backed_attribute.service.storage_path, @filename) 
         assert_equal expected_url, @storage_backed_attribute.direct_url(@filename)
       end
+
+      should 'set the expires_in time' do  
+        opts = {:expires_in => 10.minutes}
+        expected_url = @s3_helper.authenticated_url(@storage_backed_attribute.service.storage_path, @filename, opts) 
+        bad_url = @s3_helper.authenticated_url(@storage_backed_attribute.service.storage_path, @filename) 
+        
+        assert_equal expected_url, @storage_backed_attribute.direct_url(@filename, opts)
+        assert_not_equal bad_url, @storage_backed_attribute.direct_url(@filename, opts)
+      end
+      
+      should 'set the expires time' do  
+        opts = {:expires => Time.now}
+        expected_url = @s3_helper.authenticated_url(@storage_backed_attribute.service.storage_path, @filename, opts) 
+        assert_equal expected_url, @storage_backed_attribute.direct_url(@filename, opts)
+      end
     end
 
     context 'write_content_to_s3' do

--- a/test/unit/storage_backed_attributes_test.rb
+++ b/test/unit/storage_backed_attributes_test.rb
@@ -59,6 +59,16 @@ class StorageBackedAttributesTest < ActiveSupport::TestCase
 
     assert @datum.content_changed?
   end
+  
+  context 'direct url' do
+    setup do 
+      @s3_helper = ::S3::S3Helper.new('some-other-bucket', StorageBackedAttributes.storage_endpoint_config)
+    end
+
+    should 'return the authenticated url for a storage backed attribute' do
+      assert_equal @datum.content_attribute.direct_url(@datum.content_filename), @datum.content_direct_url
+    end
+  end
 
   should "define a save_content function to save to s3" do
     assert @datum.respond_to?(:save_content)


### PR DESCRIPTION
This method will return the direct url to the asset.
